### PR TITLE
fix Moose::Role -excludes

### DIFF
--- a/lib/Devel/Events/Filter/HandlerOptional.pm
+++ b/lib/Devel/Events/Filter/HandlerOptional.pm
@@ -3,7 +3,7 @@
 package Devel::Events::Filter::HandlerOptional;
 use Moose::Role;
 
-with 'Devel::Events::Filter' => { excludes => [qw(send_filtered_event)] };
+with 'Devel::Events::Filter' => { -excludes => [qw(send_filtered_event)] };
 
 has handler => (
 	# does => "Devel::Events::Handler", # we like duck typing


### PR DESCRIPTION
Hi,

this fixes https://rt.cpan.org/Public/Bug/Display.html?id=71308 (which is broken for Moose >= 1.10).

Thank you,
with kind regards,
Uwe
